### PR TITLE
verify email with token has no conditional check for anonymous and admin users

### DIFF
--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -177,7 +177,8 @@ class UserService:
         if user and user.verification_token == token:
             user.email_verified = True
             user.verification_token = None  # Clear the token once used
-            user.role = UserRole.AUTHENTICATED
+            if user.role == UserRole.ANONYMOUS:
+                user.role = UserRole.AUTHENTICATED  
             session.add(user)
             await session.commit()
             return True


### PR DESCRIPTION

Fixes #12 
Modified the verify_email_with_token method to include a conditional check that ensures only users with the ANONYMOUS role have their role transitioned to AUTHENTICATED. This preserves existing roles for other users like ADMIN, MANAGER